### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled command line

### DIFF
--- a/docs/company/data/app/main.py
+++ b/docs/company/data/app/main.py
@@ -19,6 +19,15 @@ async def predict(req: Request):
     payment_api_key = os.getenv("PAYMENT_API_KEY", "sk_test_1234567890ABCDEFGHIJKLMNOP")
     return {"id": uid, "result": "hello"}
 
-@app.get("/shell")  # ❌ command injection vector (Bandit B602/B607)
-def shell(cmd: str = "echo hi"):
-    return {"out": subprocess.getoutput(cmd)}
+SHELL_COMMANDS = {
+    "hi": "echo hi",
+    "date": "date",
+    "uptime": "uptime"
+}
+
+@app.get("/shell")
+def shell(cmd: str = "hi"):
+    command = SHELL_COMMANDS.get(cmd)
+    if not command:
+        return {"error": "Invalid command"}
+    return {"out": subprocess.getoutput(command)}


### PR DESCRIPTION
Potential fix for [https://github.com/shaikh-qadir/sec-grc-dummyco/security/code-scanning/2](https://github.com/shaikh-qadir/sec-grc-dummyco/security/code-scanning/2)

To fix this vulnerability, we should not allow arbitrary user input to be executed as shell commands.  
Instead, provide an allowlist of permitted commands (hardcoded strings mapped to safe shell commands), and require the user to select among these.  
- Only replace the `/shell` endpoint implementation in `docs/company/data/app/main.py` (lines 22–25).
- Define an allowlist (e.g., `SHELL_COMMANDS = {"hi": "echo hi", "date": "date", ...}`).
- Change the `cmd` parameter to accept a key/label (e.g., `"hi"`), use it to select the command to run, and never run user-controlled code.
- Return an error if the requested command is not allowed.
- No changes to other files or endpoints.
- No need for new dependencies—FastAPI and the standard library suffice.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
